### PR TITLE
Optimization - remove inefficient buffering when serializing to `Vec`.

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -108,10 +108,7 @@ where
 	T: Serialize,
 {
 	let mut bytes = vec![];
-	{
-		let mut buffered = io::BufWriter::new(&mut bytes);
-		serialize_into(&mut buffered, v)?;
-	}
+	serialize_into(&mut bytes, v)?;
 	Ok(bytes)
 }
 


### PR DESCRIPTION
The [documentation of `BufWriter`](https://doc.rust-lang.org/std/io/struct.BufWriter.html) states:
> It ... provides no advantage when writing to ... [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html)<u8>.

By serializing directly to our `Vec` as opposed to serializing via [the `Vec` within `BufWriter`](https://doc.rust-lang.org/src/std/io/buffered/bufwriter.rs.html#76), we safe space, time, and allocations.