### PR TITLE
Refactor - code cleanup.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -124,7 +124,7 @@ where
 	where
 		V: Visitor<'de>,
 	{
-		let b = !matches!(self.reader.read_u8()?, 0);
+		let b = self.reader.read_u8()? != 0;
 		visitor.visit_bool(b)
 	}
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -347,12 +347,7 @@ where
 	}
 
 	fn serialize_bool(self, v: bool) -> Result<()> {
-		let b = if v {
-			1
-		} else {
-			0
-		};
-		self.writer.write_u8(b)?;
+		self.writer.write_u8(v as u8)?;
 		Ok(())
 	}
 
@@ -441,7 +436,6 @@ where
 	}
 
 	fn serialize_unit(self) -> Result<()> {
-		self.writer.write_all(&[])?;
 		Ok(())
 	}
 


### PR DESCRIPTION
Note: `self.writer.write_all(&[])?;` is extraneous since [`Write::write_all` will, by default, return `Ok(())` in this case](https://doc.rust-lang.org/src/std/io/mod.rs.html#1541-1557) and other `Write` implementations should too.