### PR TITLE
Fix #3 - allow serialzing ?Sized types.

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -105,7 +105,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Serialize data into a vector of `u8` bytes.
 pub fn serialize<T>(v: &T) -> Result<Vec<u8>>
 where
-	T: Serialize,
+	T: Serialize + ?Sized,
 {
 	let mut bytes = vec![];
 	{
@@ -119,7 +119,7 @@ where
 pub fn serialize_into<W, T>(writer: W, value: &T) -> Result<()>
 where
 	W: Write,
-	T: Serialize,
+	T: Serialize + ?Sized,
 {
 	let mut serializer = Serializer::new(writer);
 	value.serialize(&mut serializer)


### PR DESCRIPTION
Fixes #3 - allows serializing `?Sized` types. Wont affect any previously-serializable types. After #7 is merged, I will add test cases in a future PR.