### PR TITLE
Bugfix #2 - seq and map support items with first byte of 0x01.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -65,14 +65,7 @@ impl<R: io::BufRead> Deserializer<R> {
 	}
 
 	pub fn move_on(&mut self) -> Result<bool> {
-		let buf = self.reader.fill_buf()?;
-		match buf.first() {
-			Some(v) if v == &0x01 => {
-				self.reader.consume(1);
-				Ok(true)
-			}
-			_ => Ok(false),
-		}
+		Ok(self.reader.read_u8()? == 0x01)
 	}
 
 	/// Deserialize a `u64` that has been serialized using the `serialize_var_u64` method.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -539,6 +539,7 @@ where
 	where
 		T: ?Sized + Serialize,
 	{
+		self.writer.write_u8(0x00)?;
 		value.serialize(&mut **self)
 	}
 
@@ -623,6 +624,7 @@ where
 	where
 		T: ?Sized + Serialize,
 	{
+		self.writer.write_u8(0x00)?;
 		value.serialize(&mut **self)
 	}
 


### PR DESCRIPTION
Fixes #2 - serialize a `0x00` byte before each item such that items that start with `0x01` don't confuse the deserializer.

This would affect previously-serialized keys.

Draft until #7 is merged and I can write a test case.