### PR TITLE
Feature - Support NUL bytes in strings and improve chars.

### DIFF
--- a/src/decode/read.rs
+++ b/src/decode/read.rs
@@ -8,6 +8,16 @@ pub enum Reference<'b, 'c> {
 	Copied(&'c [u8]),
 }
 
+impl<'a> Reference<'a, 'a> {
+	/// Use when the lifetime doesn't matter.
+	pub(crate) fn either(self) -> &'a [u8] {
+		match self {
+			Self::Borrowed(b) => b,
+			Self::Copied(b) => b,
+		}
+	}
+}
+
 /// For zero-copy reading.
 pub trait ReadReference<'de>: Read + BufRead {
 	/// Reads an exact number of bytes.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -403,16 +403,15 @@ where
 	}
 
 	fn serialize_char(self, v: char) -> Result<()> {
-		if v == 0 as char {
-			return Err(Error::Message("cannot serialize NUL char".to_owned()));
-		}
-		self.serialize_str(&v.to_string())?;
+		let mut buf = [0; 4];
+		let c = v.encode_utf8(&mut buf);
+		self.writer.write_all(c.as_bytes())?;
 		Ok(())
 	}
 
 	fn serialize_str(self, v: &str) -> Result<()> {
 		self.writer.write_all(v.as_bytes())?;
-		self.writer.write_u8(0)?;
+		self.writer.write_all(&[0, 0xFE])?;
 		Ok(())
 	}
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -151,6 +151,7 @@ fn strings() {
 	roundtrip!("".to_owned());
 	roundtrip!("hello world!".to_owned());
 	roundtrip!("adiós".to_owned());
+	roundtrip!("a\0b".to_owned());
 	less("aaa", "bbb");
 	less("a", "aa");
 	less("a\x00", "a\x01");

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -58,7 +58,6 @@ fn option() {
 }
 
 #[test]
-
 fn int() {
 	less(0, 1);
 	less(30, 1000);
@@ -112,9 +111,8 @@ fn chars() {
 		}
 	}
 
-	expect('a', &[b'a', 0]);
-
-	assert!(serialize(&'\0').is_err());
+	expect('a', &[b'a']);
+	expect('π', &[0xcf, 0x80]);
 }
 
 #[test]
@@ -138,29 +136,27 @@ fn enums() {
 }
 
 #[test]
-
 fn vector() {
 	roundtrip!(vec![2, 3, 4, 5]);
 }
 
 #[test]
-
 fn bytes() {
 	roundtrip!(vec![5u8; 9]);
 }
 
 #[test]
-
 fn strings() {
-	expect("foo".to_owned(), b"foo\0");
+	expect("foo".to_owned(), b"foo\0\xFE");
 	roundtrip!("".to_owned());
 	roundtrip!("hello world!".to_owned());
 	roundtrip!("adiós".to_owned());
 	less("aaa", "bbb");
+	less("a", "aa");
+	less("a\x00", "a\x01");
 }
 
 #[test]
-
 fn borrowed_bytes() {
 	#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 	struct Borrowed<'a> {
@@ -185,14 +181,14 @@ fn borrowed_string() {
 	}
 
 	assert_eq!(
-		deserialize::<Borrowed<'_>>(b"\0\0").unwrap(),
+		deserialize::<Borrowed<'_>>(b"\0\xFE\0\xFE").unwrap(),
 		Borrowed {
 			one: "",
 			two: ""
 		}
 	);
 	assert_eq!(
-		deserialize::<Borrowed<'_>>(b"foo\0test\0").unwrap(),
+		deserialize::<Borrowed<'_>>(b"foo\0\xFEtest\0\xFE").unwrap(),
 		Borrowed {
 			one: "foo",
 			two: "test",


### PR DESCRIPTION
### Motivation

- Doesn't support NUL bytes in strings, which is [an issue for `surrealdb`](https://github.com/surrealdb/surrealdb/issues/1912).
- Doesn't support NUL char due to the above
- Char encoding is very inefficient due to NUL-termination (2X the size in the common case without any benefit)

### Changes

- Strings are now terminated with a `\x00\xFE` sequence instead of just a `\x00` byte
  - ~~The `\x00` byte preserves lexicographic ordering~~ **(TODO: rethink this...)**
  - The `\xFE` byte (which never appears in a UTF-8 sequence) provides unambiguous termination, even in the presence of `\x00`'s in the plaintext
- No longer NUL-terminates char's
- Remove error on NUL char
- Update and expand test cases

### Note

This is a breaking change (e.g. for `surrealdb`). A migration will be required upon update.