### PR TITLE
Clarify and test float ordering.

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -39,10 +39,12 @@ use thiserror::Error;
 ///
 /// `f32` and `f64` are serialized into 4 and 8 bytes of output, respectively. Order is preserved
 /// by encoding the value, or the bitwise complement of the value if negative, into bytes in
-/// big-endian format. `NAN` values will sort after all other values. In general, it is unwise to
+/// big-endian format. The order is identical to [`f64::total_cmp`]. In general, it is unwise to
 /// use IEEE 754 floating point values in keys, because rounding errors are pervasive.  It is
 /// typically hard or impossible to use an approximate 'epsilon' approach when using keys for
 /// lookup.
+///
+/// [`f64::total_cmp`]: https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
 ///
 /// ##### Characters
 ///

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -88,9 +88,22 @@ fn fuzz_varint() {
 
 #[test]
 fn floats() {
+	const NEGATIVE_NAN: u64 = 18444492273895866368;
 	macro_rules! float {
 		($size: ty) => {
-			let ordering = [<$size>::NEG_INFINITY, -1.0, 0.0, 1.0, <$size>::INFINITY, <$size>::NAN];
+			let ordering = [
+				f64::from_bits(NEGATIVE_NAN) as $size,
+				<$size>::NEG_INFINITY,
+				-10.0,
+				-1.0,
+				-<$size>::MIN_POSITIVE,
+				0.0,
+				<$size>::MIN_POSITIVE,
+				1.0,
+				10.0,
+				<$size>::INFINITY,
+				<$size>::NAN,
+			];
 			for window in ordering.windows(2) {
 				less(&window[0], &window[1]);
 			}


### PR DESCRIPTION
The docs previously stated that `NAN` is ordered higher than all other values but that's wrong because there exist negative `NAN`'s that compare lower.

This PR makes the float test more comprehensive, confirming that the order is the same as [`f64::total_cmp`](https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp), and updates the docs.

**No new version required, since this doesn't change the behavior of the crate**