### PR TITLE
Add a generic on the Decode/DeriveDecode/Encode traits to support multiple formats per type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "storekey-derive"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ derive = ["storekey-derive"]
 uuid = ["dep:uuid"]
 
 [dependencies]
-storekey-derive = { version = "0.7.0", path = "storekey-derive", optional = true }
+storekey-derive = { version = "0.8.0", path = "storekey-derive", optional = true }
 uuid = { version = "1.17", optional = true }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -5,13 +5,13 @@ use std::time::Duration;
 
 use super::{Encode, EncodeError, Writer};
 
-impl<E: Encode + ?Sized> Encode for &E {
+impl<F, E: Encode<F> + ?Sized> Encode<F> for &E {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		E::encode(self, w)
 	}
 }
 
-impl<E: Encode> Encode for Option<E> {
+impl<F, E: Encode<F>> Encode<F> for Option<E> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		match self.as_ref() {
 			None => w.write_u8(2),
@@ -23,7 +23,7 @@ impl<E: Encode> Encode for Option<E> {
 	}
 }
 
-impl<O: Encode, E: Encode> Encode for Result<O, E> {
+impl<F, O: Encode<F>, E: Encode<F>> Encode<F> for Result<O, E> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		match self.as_ref() {
 			Ok(x) => {
@@ -38,7 +38,7 @@ impl<O: Encode, E: Encode> Encode for Result<O, E> {
 	}
 }
 
-impl Encode for bool {
+impl<F> Encode<F> for bool {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		if *self {
 			w.write_u8(3)
@@ -48,32 +48,32 @@ impl Encode for bool {
 	}
 }
 
-impl Encode for char {
+impl<F> Encode<F> for char {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		w.write_u32(*self as u32)
 	}
 }
 
-impl Encode for str {
+impl<F> Encode<F> for str {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		w.write_slice(self.as_bytes())
 	}
 }
 
-impl Encode for String {
+impl<F> Encode<F> for String {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		w.write_slice(self.as_bytes())
 	}
 }
 
-impl Encode for Duration {
+impl<F> Encode<F> for Duration {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		w.write_u64(self.as_secs())?;
 		w.write_u32(self.subsec_nanos())
 	}
 }
 
-impl<E: Encode> Encode for [E] {
+impl<F, E: Encode<F>> Encode<F> for [E] {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		for e in self.iter() {
 			w.mark_terminator();
@@ -83,7 +83,7 @@ impl<E: Encode> Encode for [E] {
 	}
 }
 
-impl<E: Encode> Encode for Vec<E> {
+impl<F, E: Encode<F>> Encode<F> for Vec<E> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		for e in self.iter() {
 			w.mark_terminator();
@@ -93,19 +93,19 @@ impl<E: Encode> Encode for Vec<E> {
 	}
 }
 
-impl<E: Encode> Encode for Box<E> {
+impl<F, E: Encode<F>> Encode<F> for Box<E> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		self.as_ref().encode(w)
 	}
 }
 
-impl<E: Encode + ToOwned + ?Sized> Encode for Cow<'_, E> {
+impl<F, E: Encode<F> + ToOwned + ?Sized> Encode<F> for Cow<'_, E> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		self.as_ref().encode(w)
 	}
 }
 
-impl<K: Encode, V: Encode, S> Encode for HashMap<K, V, S> {
+impl<F, K: Encode<F>, V: Encode<F>, S> Encode<F> for HashMap<K, V, S> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		for (k, v) in self.iter() {
 			w.mark_terminator();
@@ -116,7 +116,7 @@ impl<K: Encode, V: Encode, S> Encode for HashMap<K, V, S> {
 	}
 }
 
-impl<K: Encode, V: Encode> Encode for BTreeMap<K, V> {
+impl<F, K: Encode<F>, V: Encode<F>> Encode<F> for BTreeMap<K, V> {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		for (k, v) in self.iter() {
 			w.mark_terminator();
@@ -127,7 +127,7 @@ impl<K: Encode, V: Encode> Encode for BTreeMap<K, V> {
 	}
 }
 
-impl<T: Encode, const SIZE: usize> Encode for [T; SIZE] {
+impl<F, T: Encode<F>, const SIZE: usize> Encode<F> for [T; SIZE] {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		for i in self.iter() {
 			i.encode(w)?;
@@ -138,7 +138,7 @@ impl<T: Encode, const SIZE: usize> Encode for [T; SIZE] {
 
 macro_rules! impl_encode_tuple{
     ($($t:ident),*$(,)?) => {
-		impl <$($t: Encode),*> Encode for ($($t,)*){
+		impl <Format,$($t: Encode<Format>),*> Encode<Format> for ($($t,)*){
 			#[allow(non_snake_case)]
 			fn encode<W: Write>(&self, _w: &mut Writer<W>) -> Result<(),EncodeError> {
 				let ($($t,)*) = self;
@@ -163,7 +163,7 @@ impl_encode_tuple!(A, B, C, D, E, F);
 
 macro_rules! impl_encode_prim {
 	($ty:ident,$name:ident) => {
-		impl Encode for $ty {
+		impl<F> Encode<F> for $ty {
 			fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 				w.$name(*self)
 			}

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
+use std::ops::Bound;
 use std::time::Duration;
 
 use super::{Encode, EncodeError, Writer};
@@ -19,6 +20,22 @@ impl<F, E: Encode<F>> Encode<F> for Option<E> {
 				w.write_u8(3)?;
 				E::encode(x, w)
 			}
+		}
+	}
+}
+
+impl<F, E: Encode<F>> Encode<F> for Bound<E> {
+	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
+		match self {
+			Bound::Excluded(v) => {
+				w.write_u8(4)?;
+				Encode::encode(v, w)
+			}
+			Bound::Included(v) => {
+				w.write_u8(3)?;
+				Encode::encode(v, w)
+			}
+			Bound::Unbounded => w.write_u8(2),
 		}
 	}
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -8,19 +8,19 @@ mod uuid {
 		BorrowDecode, BorrowReader, Decode, DecodeError, Encode, EncodeError, Reader, Writer,
 	};
 
-	impl Encode for Uuid {
+	impl<F> Encode<F> for Uuid {
 		fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 			w.write_array(*self.as_bytes())
 		}
 	}
 
-	impl Decode for Uuid {
+	impl<F> Decode<F> for Uuid {
 		fn decode<R: BufRead>(r: &mut Reader<R>) -> Result<Self, DecodeError> {
 			Ok(Uuid::from_bytes(r.read_array()?))
 		}
 	}
 
-	impl<'de> BorrowDecode<'de> for Uuid {
+	impl<'de, F> BorrowDecode<'de, F> for Uuid {
 		fn borrow_decode(r: &mut BorrowReader<'de>) -> Result<Self, DecodeError> {
 			Ok(Uuid::from_bytes(r.read_array()?))
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,17 @@
 //! In general, the exact type of a serialized value must be known in order to correctly
 //! deserialize it. For structs and enums, the type is effectively frozen once any values of the
 //! type have been serialized: changes to the struct or enum will cause deserialization of already
-//! serialized values to fail or return incorrect values. The only exception is adding new variants
-//! to the end of an existing enum. Enum variants may *not* change type, be removed, or be
-//! reordered. All changes to structs, including adding, removing, reordering, or changing the type
-//! of a field are forbidden.
+//! serialized values to fail or return incorrect values.
+//!
+//! The only **limited** exception is adding new variants to the end of an existing enum.
+//! Enum variants may *not* change type, be removed, or be reordered. All changes to structs,
+//! including adding, removing, reordering, or changing the type of a field are forbidden.
+//!
+//! Adding a new variant to an proc-macro derived encoded enum will not break serialization as long
+//! as the amount of variants does not overflow the current descriminator length. In this case
+//! adding a new variant after having 254 (u8::MAX - 2) variants is breaking so is adding one after
+//! already having u16::MAX variants.
+//!
 //!
 //! These restrictions lead to a few best-practices when using `storekey` serialization:
 //!

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,13 +35,13 @@ impl EscapedSlice {
 	}
 }
 
-impl Encode for &EscapedSlice {
+impl<F> Encode<F> for EscapedSlice {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		w.write_escaped_slice(self)
 	}
 }
 
-impl<'de> BorrowDecode<'de> for &'de EscapedSlice {
+impl<'de, F> BorrowDecode<'de, F> for &'de EscapedSlice {
 	fn borrow_decode(w: &mut BorrowReader<'de>) -> Result<Self, DecodeError> {
 		w.read_escaped_slice()
 	}
@@ -151,13 +151,13 @@ impl EscapedStr {
 	}
 }
 
-impl Encode for &EscapedStr {
+impl<F> Encode<F> for EscapedStr {
 	fn encode<W: Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
 		w.write_escaped_slice(self.as_slice())
 	}
 }
 
-impl<'de> BorrowDecode<'de> for &'de EscapedStr {
+impl<'de, F> BorrowDecode<'de, F> for &'de EscapedStr {
 	fn borrow_decode(w: &mut BorrowReader<'de>) -> Result<Self, DecodeError> {
 		w.read_escaped_str()
 	}

--- a/storekey-derive/Cargo.toml
+++ b/storekey-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "storekey-derive"
 publish = true
 edition = "2024"
-version = "0.7.0"
+version = "0.8.0"
 description = "Private implementation of procedural macros for storekey"
 repository = "https://github.com/surrealdb/storekey"
 homepage = "https://github.com/surrealdb/storekey"
@@ -14,6 +14,6 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2" }
+syn = { version = "2", features = ["extra-traits"] }
 quote = { version = "1" }
 proc-macro2 = "1"

--- a/storekey-derive/src/impls/borrow_decode.rs
+++ b/storekey-derive/src/impls/borrow_decode.rs
@@ -1,0 +1,139 @@
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::quote;
+use syn::{DeriveInput, Ident, Result, parse2, spanned::Spanned};
+
+use crate::impls::{build_generics_types, extract_formats};
+
+fn impl_format(input: &DeriveInput, format: &TokenStream) -> Result<TokenStream> {
+	let mut lifetime = quote! { 'de };
+	let mut found_lifetime = false;
+	for l in input.generics.lifetimes() {
+		if found_lifetime {
+			return Err(syn::Error::new(
+				l.span(),
+				"derive(BorrowDecode) can only handle structs with no or a single lifetime",
+			));
+		}
+
+		lifetime = quote! { #l };
+		found_lifetime = true;
+	}
+
+	let name = &input.ident;
+
+	let inner = match &input.data {
+		syn::Data::Struct(data_struct) => {
+			let members = data_struct.fields.members();
+			quote! {
+				Ok(Self{
+					#(#members: ::storekey::BorrowDecode::<#format>::borrow_decode(_r)?),*
+				})
+			}
+		}
+		syn::Data::Enum(data_enum) => {
+			if data_enum.variants.is_empty() {
+				return Err(syn::Error::new(
+					data_enum.variants.span(),
+					"derive(Decode) needs enums to have atleast a single variant.",
+				));
+			}
+
+			let mut variants = Vec::new();
+
+			let decode_type = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
+				if data_enum.variants.len() > u16::MAX as usize {
+					Ident::new("u32", Span::call_site())
+				} else {
+					Ident::new("u16", Span::call_site())
+				}
+			} else {
+				Ident::new("u8", Span::call_site())
+			};
+
+			for (idx, v) in data_enum.variants.iter().enumerate() {
+				let name = &v.ident;
+
+				let idx = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
+					if data_enum.variants.len() > u16::MAX as usize {
+						Literal::u32_suffixed(idx as u32)
+					} else {
+						Literal::u16_suffixed(idx as u16)
+					}
+				} else {
+					Literal::u8_suffixed((idx as u8) + 2)
+				};
+
+				let bind_fields = match &v.fields {
+					syn::Fields::Named(_) => {
+						let members = v.fields.members();
+
+						quote! {
+							#idx => Ok(Self::#name{
+								#(#members: ::storekey::BorrowDecode::<#format>::borrow_decode(_r)?),*
+							})
+						}
+					}
+					syn::Fields::Unnamed(fields_unnamed) => {
+						let decode = fields_unnamed.unnamed.iter().map(|_| {
+							quote! {
+								::storekey::BorrowDecode::<#format>::borrow_decode(_r)?
+							}
+						});
+
+						quote! {
+							#idx => Ok(Self::#name(
+									#(#decode),*
+							))
+						}
+					}
+					syn::Fields::Unit => {
+						quote! {
+							#idx => Ok(Self::#name)
+						}
+					}
+				};
+
+				variants.push(bind_fields);
+			}
+
+			quote! {
+				let variant: #decode_type = ::storekey::BorrowDecode::<#format>::borrow_decode(_r)?;
+				match variant {
+					#(#variants,)*
+					_ => Err(::storekey::DecodeError::InvalidFormat)
+				}
+			}
+		}
+		syn::Data::Union(u) => {
+			return Err(syn::Error::new(
+				u.union_token.span,
+				"derive(BorrowDecode) is not supported for Unions",
+			));
+		}
+	};
+
+	let (_, ty_generics, where_clause) = input.generics.split_for_impl();
+	let type_bounds = build_generics_types(
+		parse2(quote! { ::storekey::BorrowDecode<#lifetime, #format> }).unwrap(),
+		&input.generics,
+	);
+	let consts = input.generics.const_params();
+
+	Ok(quote! {
+		impl <#lifetime, #type_bounds #(#consts,)* > ::storekey::BorrowDecode<#lifetime, #format> for #name #ty_generics #where_clause {
+			fn borrow_decode(_r: &mut ::storekey::BorrowReader<#lifetime>) -> ::std::result::Result<Self, ::storekey::DecodeError>{
+				#inner
+			}
+		}
+	})
+}
+
+pub fn borrow_decode(input: TokenStream) -> Result<TokenStream> {
+	let input = parse2::<DeriveInput>(input)?;
+
+	let f = extract_formats(&input.attrs)?;
+
+	let formats = f.iter().map(|x| impl_format(&input, x)).collect::<Result<Vec<TokenStream>>>()?;
+
+	Ok(quote! { #(#formats)* })
+}

--- a/storekey-derive/src/impls/decode.rs
+++ b/storekey-derive/src/impls/decode.rs
@@ -1,0 +1,126 @@
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::quote;
+use syn::{DeriveInput, Ident, Result, parse2, spanned::Spanned};
+
+use crate::impls::{build_generics_types, extract_formats};
+
+pub fn impl_format(input: &DeriveInput, format: &TokenStream) -> Result<TokenStream> {
+	let name = &input.ident;
+
+	let inner = match &input.data {
+		syn::Data::Struct(data_struct) => {
+			let members = data_struct.fields.members();
+			quote! {
+				Ok(Self{
+					#(#members: ::storekey::Decode::<#format>::decode(_r)?),*
+				})
+			}
+		}
+		syn::Data::Enum(data_enum) => {
+			if data_enum.variants.is_empty() {
+				return Err(syn::Error::new(
+					data_enum.variants.span(),
+					"derive(Decode) needs enums to have atleast a single variant.",
+				));
+			}
+
+			let mut variants = Vec::new();
+
+			let decode_type = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
+				if data_enum.variants.len() > u16::MAX as usize {
+					Ident::new("u32", Span::call_site())
+				} else {
+					Ident::new("u16", Span::call_site())
+				}
+			} else {
+				Ident::new("u8", Span::call_site())
+			};
+
+			for (idx, v) in data_enum.variants.iter().enumerate() {
+				let name = &v.ident;
+
+				let idx = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
+					if data_enum.variants.len() > u16::MAX as usize {
+						Literal::u32_suffixed(idx as u32)
+					} else {
+						Literal::u16_suffixed(idx as u16)
+					}
+				} else {
+					Literal::u8_suffixed((idx as u8) + 2)
+				};
+
+				let bind_fields = match &v.fields {
+					syn::Fields::Named(_) => {
+						let members = v.fields.members();
+
+						quote! {
+							#idx => Ok(Self::#name{
+								#(#members: ::storekey::Decode::<#format>::decode(_r)?),*
+							})
+						}
+					}
+					syn::Fields::Unnamed(fields_unnamed) => {
+						let decode = fields_unnamed.unnamed.iter().map(|_| {
+							quote! {
+								::storekey::Decode::<#format>::decode(_r)?
+							}
+						});
+
+						quote! {
+							#idx => Ok(Self::#name(
+									#(#decode),*
+							))
+						}
+					}
+					syn::Fields::Unit => {
+						quote! {
+							#idx => Ok(Self::#name)
+						}
+					}
+				};
+
+				variants.push(bind_fields);
+			}
+
+			quote! {
+				let variant: #decode_type = ::storekey::Decode::<#format>::decode(_r)?;
+				match variant {
+					#(#variants,)*
+					_ => Err(::storekey::DecodeError::InvalidFormat)
+				}
+			}
+		}
+		syn::Data::Union(u) => {
+			return Err(syn::Error::new(
+				u.union_token.span,
+				"derive(Decode) is not supported for Unions",
+			));
+		}
+	};
+
+	let (_, ty_generics, where_clause) = input.generics.split_for_impl();
+	let type_bounds = build_generics_types(
+		parse2(quote! { ::storekey::Decode<#format> }).unwrap(),
+		&input.generics,
+	);
+	let lifetimes = input.generics.lifetimes();
+	let consts = input.generics.const_params();
+
+	Ok(quote! {
+		impl <#(#lifetimes,)* #type_bounds #(#consts,)* > ::storekey::Decode<#format> for #name #ty_generics #where_clause {
+			fn decode<R: ::std::io::BufRead>(_r: &mut ::storekey::Reader<R>) -> ::std::result::Result<Self, ::storekey::DecodeError>{
+				#inner
+			}
+		}
+	})
+}
+
+pub fn decode(input: TokenStream) -> Result<TokenStream> {
+	let input = parse2::<DeriveInput>(input)?;
+
+	let formats = extract_formats(&input.attrs)?;
+
+	let formats = formats.iter().map(|x| impl_format(&input, x)).collect::<Result<Vec<_>>>()?;
+
+	Ok(quote! { #(#formats)* })
+}

--- a/storekey-derive/src/impls/encode.rs
+++ b/storekey-derive/src/impls/encode.rs
@@ -1,0 +1,130 @@
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Ident, Result, parse2, spanned::Spanned};
+
+use crate::impls::{build_generics_types, extract_formats};
+
+pub fn impl_format(input: &DeriveInput, format: &TokenStream) -> Result<TokenStream> {
+	let name = &input.ident;
+
+	let inner = match &input.data {
+		syn::Data::Struct(data_struct) => {
+			let members = data_struct.fields.members();
+			quote! {
+				#(::storekey::Encode::<#format>::encode(&self.#members,_w)?;)*
+			}
+		}
+		syn::Data::Enum(data_enum) => {
+			if data_enum.variants.is_empty() {
+				return Err(syn::Error::new(
+					data_enum.variants.span(),
+					"derive(Encode) needs enums to have atleast a single variant.",
+				));
+			}
+
+			let mut variants = Vec::new();
+
+			let decode_type = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
+				if data_enum.variants.len() > u16::MAX as usize {
+					Ident::new("u32", Span::call_site())
+				} else {
+					Ident::new("u16", Span::call_site())
+				}
+			} else {
+				Ident::new("u8", Span::call_site())
+			};
+
+			for (idx, v) in data_enum.variants.iter().enumerate() {
+				let name = &v.ident;
+
+				let idx = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
+					if data_enum.variants.len() > u16::MAX as usize {
+						Literal::u32_suffixed(idx as u32)
+					} else {
+						Literal::u16_suffixed(idx as u16)
+					}
+				} else {
+					Literal::u8_suffixed((idx as u8) + 2)
+				};
+
+				match &v.fields {
+					syn::Fields::Named(_) => {
+						let members = v.fields.members();
+						let members_b = v.fields.members();
+
+						variants.push(quote! {
+							Self::#name{
+								#(#members),*
+							} => {
+								let discriminant: #decode_type = #idx;
+								::storekey::Encode::<#format>::encode(&discriminant,_w)?;
+								#(::storekey::Encode::<#format>::encode(&#members_b,_w)?;)*
+							}
+						});
+					}
+					syn::Fields::Unnamed(fields_unnamed) => {
+						let fields = fields_unnamed
+							.unnamed
+							.iter()
+							.enumerate()
+							.map(|(idx, _)| format_ident!("field_{idx}"))
+							.collect::<Vec<_>>();
+
+						variants.push(quote! {
+							Self::#name(
+								#(#fields),*
+							) => {
+								let discriminant: #decode_type = #idx;
+								::storekey::Encode::<#format>::encode(&discriminant,_w)?;
+								#(::storekey::Encode::<#format>::encode(&#fields,_w)?;)*
+							}
+						});
+					}
+					syn::Fields::Unit => variants.push(quote! {
+						Self::#name => {
+							let discriminant: #decode_type = #idx;
+							::storekey::Encode::<#format>::encode(&discriminant,_w)?;
+						}
+					}),
+				};
+			}
+
+			quote! {
+				match self{
+					#(#variants),*
+				}
+			}
+		}
+		syn::Data::Union(u) => {
+			return Err(syn::Error::new(
+				u.union_token.span,
+				"derive(Encode) is not supported for Unions",
+			));
+		}
+	};
+
+	let (_, ty_generics, where_clause) = input.generics.split_for_impl();
+	let type_bounds =
+		build_generics_types(parse2(quote! { ::storekey::Encode }).unwrap(), &input.generics);
+	let lifetimes = input.generics.lifetimes();
+	let consts = input.generics.const_params();
+
+	Ok(quote! {
+		impl <#(#lifetimes,)* #type_bounds #(#consts,)* > ::storekey::Encode<#format> for #name  #ty_generics #where_clause {
+			fn encode<W: ::std::io::Write>(&self, _w: &mut ::storekey::Writer<W>) -> ::std::result::Result<(), ::storekey::EncodeError>{
+				#inner
+				Ok(())
+			}
+		}
+	})
+}
+
+pub fn encode(input: TokenStream) -> Result<TokenStream> {
+	let input = parse2::<DeriveInput>(input)?;
+
+	let formats = extract_formats(&input.attrs)?;
+
+	let formats = formats.iter().map(|x| impl_format(&input, x)).collect::<Result<Vec<_>>>()?;
+
+	Ok(quote! { #(#formats)* })
+}

--- a/storekey-derive/src/impls/mod.rs
+++ b/storekey-derive/src/impls/mod.rs
@@ -1,8 +1,21 @@
-use proc_macro2::{Literal, Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
+use syn::parse::Parse;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{DeriveInput, Generics, Ident, Result, Token, TypeParamBound, parse2};
+use syn::{
+	Attribute, DeriveInput, Generics, LitStr, Result, Token, TypeParamBound, custom_keyword, parse2,
+};
+
+mod borrow_decode;
+mod decode;
+mod encode;
+
+pub use borrow_decode::borrow_decode;
+pub use decode::decode;
+pub use encode::encode;
+
+custom_keyword!(format);
 
 fn build_generics_types(bound: TypeParamBound, generics: &Generics) -> TokenStream {
 	let mut types = Punctuated::<_, Token![,]>::new();
@@ -23,358 +36,31 @@ fn build_generics_types(bound: TypeParamBound, generics: &Generics) -> TokenStre
 	types.into_token_stream()
 }
 
-pub fn encode(input: TokenStream) -> Result<TokenStream> {
-	let input = parse2::<DeriveInput>(input)?;
+fn extract_formats(attrs: &[Attribute]) -> Result<Vec<TokenStream>> {
+	struct Format(TokenStream);
 
-	let name = input.ident;
-
-	let inner = match input.data {
-		syn::Data::Struct(data_struct) => {
-			let members = data_struct.fields.members();
-			quote! {
-				#(::storekey::Encode::encode(&self.#members,_w)?;)*
-			}
+	impl Parse for Format {
+		fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+			input.parse::<format>()?;
+			input.parse::<Token![=]>()?;
+			let l = input.parse::<LitStr>()?;
+			Ok(Format(l.parse::<TokenStream>()?))
 		}
-		syn::Data::Enum(data_enum) => {
-			if data_enum.variants.is_empty() {
-				return Err(syn::Error::new(
-					data_enum.variants.span(),
-					"derive(Encode) needs enums to have atleast a single variant.",
-				));
-			}
-
-			let mut variants = Vec::new();
-
-			let decode_type = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
-				if data_enum.variants.len() > u16::MAX as usize {
-					Ident::new("u32", Span::call_site())
-				} else {
-					Ident::new("u16", Span::call_site())
-				}
-			} else {
-				Ident::new("u8", Span::call_site())
-			};
-
-			for (idx, v) in data_enum.variants.iter().enumerate() {
-				let name = &v.ident;
-
-				let idx = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
-					if data_enum.variants.len() > u16::MAX as usize {
-						Literal::u32_suffixed(idx as u32)
-					} else {
-						Literal::u16_suffixed(idx as u16)
-					}
-				} else {
-					Literal::u8_suffixed((idx as u8) + 2)
-				};
-
-				match &v.fields {
-					syn::Fields::Named(_) => {
-						let members = v.fields.members();
-						let members_b = v.fields.members();
-
-						variants.push(quote! {
-							Self::#name{
-								#(#members),*
-							} => {
-								let discriminant: #decode_type = #idx;
-								::storekey::Encode::encode(&discriminant,_w)?;
-								#(::storekey::Encode::encode(&#members_b,_w)?;)*
-							}
-						});
-					}
-					syn::Fields::Unnamed(fields_unnamed) => {
-						let fields = fields_unnamed
-							.unnamed
-							.iter()
-							.enumerate()
-							.map(|(idx, _)| format_ident!("field_{idx}"))
-							.collect::<Vec<_>>();
-
-						variants.push(quote! {
-							Self::#name(
-								#(#fields),*
-							) => {
-								let discriminant: #decode_type = #idx;
-								::storekey::Encode::encode(&discriminant,_w)?;
-								#(::storekey::Encode::encode(&#fields,_w)?;)*
-							}
-						});
-					}
-					syn::Fields::Unit => variants.push(quote! {
-						Self::#name => {
-							let discriminant: #decode_type = #idx;
-							::storekey::Encode::encode(&discriminant,_w)?;
-						}
-					}),
-				};
-			}
-
-			quote! {
-				match self{
-					#(#variants),*
-				}
-			}
-		}
-		syn::Data::Union(u) => {
-			return Err(syn::Error::new(
-				u.union_token.span,
-				"derive(Encode) is not supported for Unions",
-			));
-		}
-	};
-
-	let (_, ty_generics, where_clause) = input.generics.split_for_impl();
-	let type_bounds =
-		build_generics_types(parse2(quote! { ::storekey::Encode }).unwrap(), &input.generics);
-	let lifetimes = input.generics.lifetimes();
-	let consts = input.generics.const_params();
-
-	Ok(quote! {
-		impl <#(#lifetimes,)* #type_bounds #(#consts,)* > ::storekey::Encode for #name  #ty_generics #where_clause {
-			fn encode<W: ::std::io::Write>(&self, _w: &mut ::storekey::Writer<W>) -> ::std::result::Result<(), ::storekey::EncodeError>{
-				#inner
-				Ok(())
-			}
-		}
-	})
-}
-
-pub fn decode(input: TokenStream) -> Result<TokenStream> {
-	let input = parse2::<DeriveInput>(input)?;
-
-	let name = input.ident;
-
-	let inner = match input.data {
-		syn::Data::Struct(data_struct) => {
-			let members = data_struct.fields.members();
-			quote! {
-				Ok(Self{
-					#(#members: ::storekey::Decode::decode(_r)?),*
-				})
-			}
-		}
-		syn::Data::Enum(data_enum) => {
-			if data_enum.variants.is_empty() {
-				return Err(syn::Error::new(
-					data_enum.variants.span(),
-					"derive(Decode) needs enums to have atleast a single variant.",
-				));
-			}
-
-			let mut variants = Vec::new();
-
-			let decode_type = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
-				if data_enum.variants.len() > u16::MAX as usize {
-					Ident::new("u32", Span::call_site())
-				} else {
-					Ident::new("u16", Span::call_site())
-				}
-			} else {
-				Ident::new("u8", Span::call_site())
-			};
-
-			for (idx, v) in data_enum.variants.iter().enumerate() {
-				let name = &v.ident;
-
-				let idx = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
-					if data_enum.variants.len() > u16::MAX as usize {
-						Literal::u32_suffixed(idx as u32)
-					} else {
-						Literal::u16_suffixed(idx as u16)
-					}
-				} else {
-					Literal::u8_suffixed((idx as u8) + 2)
-				};
-
-				let bind_fields = match &v.fields {
-					syn::Fields::Named(_) => {
-						let members = v.fields.members();
-
-						quote! {
-							#idx => Ok(Self::#name{
-								#(#members: ::storekey::Decode::decode(_r)?),*
-							})
-						}
-					}
-					syn::Fields::Unnamed(fields_unnamed) => {
-						let decode = fields_unnamed.unnamed.iter().map(|_| {
-							quote! {
-								::storekey::Decode::decode(_r)?
-							}
-						});
-
-						quote! {
-							#idx => Ok(Self::#name(
-									#(#decode),*
-							))
-						}
-					}
-					syn::Fields::Unit => {
-						quote! {
-							#idx => Ok(Self::#name)
-						}
-					}
-				};
-
-				variants.push(bind_fields);
-			}
-
-			quote! {
-				let variant: #decode_type = ::storekey::Decode::decode(_r)?;
-				match variant {
-					#(#variants,)*
-					_ => Err(::storekey::DecodeError::InvalidFormat)
-				}
-			}
-		}
-		syn::Data::Union(u) => {
-			return Err(syn::Error::new(
-				u.union_token.span,
-				"derive(Decode) is not supported for Unions",
-			));
-		}
-	};
-
-	let (_, ty_generics, where_clause) = input.generics.split_for_impl();
-	let type_bounds =
-		build_generics_types(parse2(quote! { ::storekey::Decode }).unwrap(), &input.generics);
-	let lifetimes = input.generics.lifetimes();
-	let consts = input.generics.const_params();
-
-	Ok(quote! {
-		impl <#(#lifetimes,)* #type_bounds #(#consts,)* > ::storekey::Decode for #name #ty_generics #where_clause {
-			fn decode<R: ::std::io::BufRead>(_r: &mut ::storekey::Reader<R>) -> ::std::result::Result<Self, ::storekey::DecodeError>{
-				#inner
-			}
-		}
-	})
-}
-
-pub fn borrow_decode(input: TokenStream) -> Result<TokenStream> {
-	let input = parse2::<DeriveInput>(input)?;
-
-	let mut lifetime = quote! { 'de };
-	let mut found_lifetime = false;
-	for l in input.generics.lifetimes() {
-		if found_lifetime {
-			return Err(syn::Error::new(
-				l.span(),
-				"derive(BorrowDecode) can only handle structs with no or a single lifetime",
-			));
-		}
-
-		lifetime = quote! { #l };
-		found_lifetime = true;
 	}
 
-	let name = input.ident;
+	let mut res = Vec::new();
 
-	let inner = match input.data {
-		syn::Data::Struct(data_struct) => {
-			let members = data_struct.fields.members();
-			quote! {
-				Ok(Self{
-					#(#members: ::storekey::BorrowDecode::borrow_decode(_r)?),*
-				})
-			}
+	for at in attrs {
+		if at.path().is_ident("storekey") {
+			res.push(at.parse_args::<Format>()?.0);
 		}
-		syn::Data::Enum(data_enum) => {
-			if data_enum.variants.is_empty() {
-				return Err(syn::Error::new(
-					data_enum.variants.span(),
-					"derive(Decode) needs enums to have atleast a single variant.",
-				));
-			}
+	}
 
-			let mut variants = Vec::new();
+	if res.is_empty() {
+		res.push(quote! {()})
+	}
 
-			let decode_type = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
-				if data_enum.variants.len() > u16::MAX as usize {
-					Ident::new("u32", Span::call_site())
-				} else {
-					Ident::new("u16", Span::call_site())
-				}
-			} else {
-				Ident::new("u8", Span::call_site())
-			};
-
-			for (idx, v) in data_enum.variants.iter().enumerate() {
-				let name = &v.ident;
-
-				let idx = if data_enum.variants.len() > (u8::MAX as usize) - 2 {
-					if data_enum.variants.len() > u16::MAX as usize {
-						Literal::u32_suffixed(idx as u32)
-					} else {
-						Literal::u16_suffixed(idx as u16)
-					}
-				} else {
-					Literal::u8_suffixed((idx as u8) + 2)
-				};
-
-				let bind_fields = match &v.fields {
-					syn::Fields::Named(_) => {
-						let members = v.fields.members();
-
-						quote! {
-							#idx => Ok(Self::#name{
-								#(#members: ::storekey::BorrowDecode::borrow_decode(_r)?),*
-							})
-						}
-					}
-					syn::Fields::Unnamed(fields_unnamed) => {
-						let decode = fields_unnamed.unnamed.iter().map(|_| {
-							quote! {
-								::storekey::BorrowDecode::borrow_decode(_r)?
-							}
-						});
-
-						quote! {
-							#idx => Ok(Self::#name(
-									#(#decode),*
-							))
-						}
-					}
-					syn::Fields::Unit => {
-						quote! {
-							#idx => Ok(Self::#name)
-						}
-					}
-				};
-
-				variants.push(bind_fields);
-			}
-
-			quote! {
-				let variant: #decode_type = ::storekey::BorrowDecode::borrow_decode(_r)?;
-				match variant {
-					#(#variants,)*
-					_ => Err(::storekey::DecodeError::InvalidFormat)
-				}
-			}
-		}
-		syn::Data::Union(u) => {
-			return Err(syn::Error::new(
-				u.union_token.span,
-				"derive(BorrowDecode) is not supported for Unions",
-			));
-		}
-	};
-
-	let (_, ty_generics, where_clause) = input.generics.split_for_impl();
-	let type_bounds = build_generics_types(
-		parse2(quote! { ::storekey::BorrowDecode<#lifetime> }).unwrap(),
-		&input.generics,
-	);
-	let consts = input.generics.const_params();
-
-	Ok(quote! {
-		impl <#lifetime, #type_bounds #(#consts,)* > ::storekey::BorrowDecode<#lifetime> for #name #ty_generics #where_clause {
-			fn borrow_decode(_r: &mut ::storekey::BorrowReader<#lifetime>) -> ::std::result::Result<Self, ::storekey::DecodeError>{
-				#inner
-			}
-		}
-	})
+	Ok(res)
 }
 
 pub fn to_escaped(input: TokenStream) -> Result<TokenStream> {

--- a/storekey-derive/src/impls/mod.rs
+++ b/storekey-derive/src/impls/mod.rs
@@ -56,10 +56,6 @@ fn extract_formats(attrs: &[Attribute]) -> Result<Vec<TokenStream>> {
 		}
 	}
 
-	if res.is_empty() {
-		res.push(quote! {()})
-	}
-
 	Ok(res)
 }
 

--- a/storekey-derive/src/lib.rs
+++ b/storekey-derive/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 
 mod impls;
 
-#[proc_macro_derive(Encode)]
+#[proc_macro_derive(Encode, attributes(storekey))]
 pub fn encode(input: TokenStream) -> TokenStream {
 	match impls::encode(input.into()) {
 		Ok(x) => x.into(),
@@ -10,7 +10,7 @@ pub fn encode(input: TokenStream) -> TokenStream {
 	}
 }
 
-#[proc_macro_derive(Decode)]
+#[proc_macro_derive(Decode, attributes(storekey))]
 pub fn decode(input: TokenStream) -> TokenStream {
 	match impls::decode(input.into()) {
 		Ok(x) => x.into(),
@@ -18,7 +18,7 @@ pub fn decode(input: TokenStream) -> TokenStream {
 	}
 }
 
-#[proc_macro_derive(BorrowDecode)]
+#[proc_macro_derive(BorrowDecode, attributes(storekey))]
 pub fn borrow_decode(input: TokenStream) -> TokenStream {
 	match impls::borrow_decode(input.into()) {
 		Ok(x) => x.into(),

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -180,6 +180,7 @@ fn basic_enum() {
 pub enum OtherFormat {}
 
 #[derive(Encode)]
+#[storekey(format = "()")]
 pub struct EncodeDiff(u16);
 
 impl Encode<OtherFormat> for EncodeDiff {


### PR DESCRIPTION
This PR adds a `Format` generic on the Decode/DeriveDecode/Encode traits.

This allows one to implement multiple different formats for the same type by implementing encode multiple times using different types for the Format generic.

The default format is `()` and proc-macros will default to implementing `Encode<()>` however you can now also specify a format to derive by adding `#[storekey(format = "OtherFormat")]`. 